### PR TITLE
firewall_forwarded_tcp_ports does not forward connections from localhost

### DIFF
--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -40,9 +40,11 @@ iptables -A INPUT -i lo -j ACCEPT
 {# Add a rule for each forwarded port #}
 {% for forwarded_port in firewall_forwarded_tcp_ports %}
 iptables -t nat -I PREROUTING -p tcp --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
+iptables -t nat -I OUTPUT -p tcp -o lo --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
 {% endfor %}
 {% for forwarded_port in firewall_forwarded_udp_ports %}
 iptables -t nat -I PREROUTING -p udp --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
+iptables -t nat -I OUTPUT -p udp -o lo --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
 {% endfor %}
 
 # Open ports.


### PR DESCRIPTION
When accessing the forwarded port from the managed machine itself, connections are refused

```
$ cat vars/main.yml
firewall_allowed_tcp_ports:
  - "22"   # SSH
  - "80"   # Redirect (below)
  - "8080"

firewall_forwarded_tcp_ports:
  - { src: "80", dest: "8080" }
```

After applying the above, port 80 can be accessed from other machines, but connections from localhost receive `Connection refused`.  (Note: port 8080 has a web server, and connections to 8080 are accepted.)
