### PR TITLE
Fix ip6tables always being executed

### DIFF
--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -89,7 +89,7 @@ iptables -A INPUT -j DROP
 
 
 # Configure IPv6 if ip6tables is present.
-if [ -x $(which ip6tables) ]; then
+if [ -x "$(which ip6tables 2>/dev/null)" ]; then
 
   # Remove all rules and chains.
   ip6tables -F


### PR DESCRIPTION
`[ -x $(which ip6tables) ]` always evaluates to true because it's not quoted.

the evaluation goes:

1. `[ -x $(which ip6tables) ]`
2. `[ -x ]`
3. true, same as `[ -{ ]` is