### PR TITLE
Disable firewalld/ufw service only when appropriate package is installed

### DIFF
--- a/tasks/disable-other-firewalls.yml
+++ b/tasks/disable-other-firewalls.yml
@@ -1,14 +1,26 @@
 ---
+- name: Check firewalld package is installed (on RHEL).
+  shell: yum list installed firewalld
+  register: firewalld_installed
+  ignore_errors: true
+  when: ansible_os_family == "RedHat" and firewall_disable_firewalld
+
 - name: Disable the firewalld service (on RHEL, if configured).
   service:
     name: firewalld
     state: stopped
     enabled: no
-  when: ansible_os_family == "RedHat" and firewall_disable_firewalld
+  when: ansible_os_family == "RedHat" and firewall_disable_firewalld and firewalld_installed.rc == 0
+
+- name: Check ufw package is installed (on Ubuntu).
+  shell: dpkg -l ufw
+  register: ufw_installed
+  ignore_errors: true
+  when: ansible_distribution == "Ubuntu" and firewall_disable_ufw
 
 - name: Disable the ufw firewall (on Ubuntu, if configured).
   service:
     name: ufw
     state: stopped
     enabled: no
-  when: ansible_distribution == "Ubuntu" and firewall_disable_ufw
+  when: ansible_distribution == "Ubuntu" and firewall_disable_ufw and ufw_installed.rc == 0


### PR DESCRIPTION
When I run playbook on the system without firewalld, I've got an error:
```
TASK [geerlingguy.firewall : Disable the firewalld service (on RHEL, if configured).] ***
task path: ...roles/geerlingguy.firewall/tasks/disable-other-firewalls.yml:2
...
fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "daemon_reload": false,
            "enabled": false,
            "masked": null,
            "name": "firewalld",
            "state": "stopped",
            "user": false
        }
    },
    "msg": "Could not find the requested service firewalld: cannot disable"
}
```

So I think we must check that firewalld package installed before disabling it.