### PR TITLE
Fix ip6tables icmp rule protocol bug

### DIFF
--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -108,7 +108,7 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
   {% endfor %}
 
   # Accept icmp ping requests.
-  ip6tables -A INPUT -p icmp -j ACCEPT
+  ip6tables -A INPUT -p icmpv6 -j ACCEPT
 
   # Allow NTP traffic for time synchronization.
   ip6tables -A OUTPUT -p udp --dport 123 -j ACCEPT


### PR DESCRIPTION
Hi

I seen some iptables dropped log like this when I used default settings.

```
Feb 23 03:17:19 ubuntu kernel: Dropped by firewall: IN=eth0 OUT= MAC=33:33:00:00:00:01:00:05:73:a0:xx:xx:xx:xx SRC=xxxx:0000:0000:0000:0000:0000:0000:0001 DST=xxxx:0000:0000:0000:0000:0000:0000:0001 LEN=104 TC=224 HOPLIMIT=255 FLOWLBL=0 PROTO=ICMPv6 TYPE=134 CODE=0
```

That is because ip6tables icmp protocol is mismatch. [Ref](https://linux.die.net/man/8/ip6tables)

Please review it. thanks.

