### PR TITLE
Fixed mode on systemd service

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
     dest: /etc/systemd/system/firewall.service
     owner: root
     group: root
-    mode: 0755
+    mode: 0644
   when: >
     (ansible_distribution == 'Ubuntu' and ansible_distribution_version.split(".")[0]|int >= 16) or
     (ansible_distribution == 'Debian' and ansible_distribution_version.split(".")[0]|int >= 8) or


### PR DESCRIPTION
My syslog shows a lot of these messages:

`systemd[1]: Configuration file /etc/systemd/system/firewall.service is marked executable. Please remove executable permission bits. Proceeding anyway.`

This can be resolved by setting permissions on the service script to 0644, which is what this pull request does.