### PR TITLE
Add support for Archlinux and other systemd distros.

### DIFF
--- a/tasks/disable-other-firewalls.yml
+++ b/tasks/disable-other-firewalls.yml
@@ -26,3 +26,17 @@
     state: stopped
     enabled: no
   when: ansible_distribution == "Ubuntu" and firewall_disable_ufw and ufw_installed.rc == 0
+
+- name: Check ufw package is installed (on Archlinux).
+  command: pacman -Q ufw
+  register: ufw_installed
+  ignore_errors: true
+  changed_when: false
+  when: ansible_distribution == "Archlinux" and firewall_disable_ufw
+
+- name: Disable the ufw firewall (on Archlinux, if configured).
+  service:
+    name: ufw
+    state: stopped
+    enabled: no
+  when: ansible_distribution == "Archlinux" and firewall_disable_ufw and ufw_installed.rc == 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Flush iptables the first time playbook runs.
   command: >
     iptables -F
-    creates=/etc/init.d/firewall
+    creates=/etc/firewall.bash
 
 - name: Copy firewall script into place.
   template:
@@ -23,6 +23,7 @@
     owner: root
     group: root
     mode: 0755
+  when: "ansible_service_mgr != 'systemd'"
 
 - name: Copy firewall systemd unit file into place (for systemd systems).
   template:
@@ -31,11 +32,7 @@
     owner: root
     group: root
     mode: 0644
-  when: >
-    (ansible_distribution == 'Ubuntu' and ansible_distribution_version.split(".")[0]|int >= 16) or
-    (ansible_distribution == 'Debian' and ansible_distribution_version.split(".")[0]|int >= 8) or
-    (ansible_os_family == 'RedHat' and ansible_distribution_version.split(".")[0]|int >= 7) or
-    (ansible_distribution == 'Fedora')
+  when: "ansible_service_mgr == 'systemd'"
 
 - name: Ensure the firewall is enabled and will start on boot.
   service: name=firewall state=started enabled=yes


### PR DESCRIPTION
Hi @geerlingguy ,

I've added support for Archlinux by changing the checks done when setting up the init file. I'm using the `ansible_service_mgr` fact, which tells you which init system the host is using. This way, there's no need for explicitly check the distribution/family.

I've also added a check for `ufw` for Archlinux, similar to the ones already in place.

Thank you!