### PR TITLE
clear raw table

### DIFF
--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -35,6 +35,7 @@ iptables -P FORWARD ACCEPT
 iptables -P OUTPUT ACCEPT
 iptables -t nat -F
 iptables -t mangle -F
+iptables -t raw -F
 iptables -F
 iptables -X
 


### PR DESCRIPTION
Use case for this is clearing added rules for something like `NOTRACK`.

e.g.
```
iptables -t raw -I PREROUTING -p udp --dport 53 -j CT --notrack
iptables -t raw -I PREROUTING -p udp --sport 53 -j CT --notrack
iptables -t raw -I OUTPUT -p udp --dport 53 -j CT --notrack
iptables -t raw -I OUTPUT -p udp --sport 53 -j CT --notrack```