### PR TITLE
Backup the firewall script when change detected

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,7 @@
     owner: root
     group: root
     mode: 0744
+    backup: true
   notify: restart firewall
 
 - name: Copy firewall init script into place.


### PR DESCRIPTION
Backup the filewall script in order to have a copy on the server which allows for easy change tracking and quick rollback if required.