### PR TITLE
Make the role more configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Any additional (custom) rules to be added to the firewall (in the same format yo
     firewall_additional_rules:
       - "iptables -A INPUT -p tcp --dport 3306 -s 214.192.48.21 -j ACCEPT"
 
+Allow incoming icmp (ping) traffic.
+
+    firewall_allow_incoming_icmp: true
+
 See [Iptables Essentials: Common Firewall Rules and Commands](https://www.digitalocean.com/community/tutorials/iptables-essentials-common-firewall-rules-and-commands) for more examples.
 
     firewall_log_dropped_packets: true

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Allow incoming icmp (ping) traffic.
 
     firewall_allow_incoming_icmp: true
 
+Allow incoming/outgoing ntp traffic.
+
+    firewall_allow_ntp: true
+
 See [Iptables Essentials: Common Firewall Rules and Commands](https://www.digitalocean.com/community/tutorials/iptables-essentials-common-firewall-rules-and-commands) for more examples.
 
     firewall_log_dropped_packets: true

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ See [Iptables Essentials: Common Firewall Rules and Commands](https://www.digita
 
     firewall_log_dropped_packets: true
 
+Configure default policies for INPUT/FORWARD/OUTPUT chains in the filter table.  
+See [mcastelino's iptables cheat sheet](https://gist.github.com/mcastelino/c38e71eb0809d1427a6650d843c42ac2#targets-1) for valid targets.
+
+    firewall_input_filter_policy: DROP
+    firewall_forward_filter_policy: ACCEPT
+    firewall_output_filter_policy: ACCEPT
+
 Whether to log dropped packets to syslog (messages will be prefixed with "Dropped by firewall: ").
 
     firewall_disable_firewalld: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,9 @@ firewall_ip6_additional_rules: []
 firewall_allow_incoming_icmp: true
 firewall_allow_ntp: true
 firewall_log_dropped_packets: true
+firewall_input_filter_policy: DROP
+firewall_forward_filter_policy: ACCEPT
+firewall_output_filter_policy: ACCEPT
 
 # Set to true to ensure other firewall management software is disabled.
 firewall_disable_firewalld: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ firewall_forwarded_udp_ports: []
 firewall_additional_rules: []
 firewall_ip6_additional_rules: []
 firewall_allow_incoming_icmp: true
+firewall_allow_ntp: true
 firewall_log_dropped_packets: true
 
 # Set to true to ensure other firewall management software is disabled.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ firewall_forwarded_tcp_ports: []
 firewall_forwarded_udp_ports: []
 firewall_additional_rules: []
 firewall_ip6_additional_rules: []
+firewall_allow_incoming_icmp: true
 firewall_log_dropped_packets: true
 
 # Set to true to ensure other firewall management software is disabled.

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -88,8 +88,14 @@ iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A INPUT -m limit --limit 15/minute -j LOG --log-level 7 --log-prefix "Dropped by firewall: "
 {% endif %}
 
-# Drop all other traffic.
-iptables -A INPUT -j DROP
+# Configure default behavior for all other incoming traffic.
+iptables -P INPUT {{ firewall_input_filter_policy }}
+
+# Configure default behavior for all other forwarded traffic.
+iptables -P FORWARD {{ firewall_forward_filter_policy }}
+
+# Configure default behavior for all other outgoing traffic.
+iptables -P OUTPUT {{ firewall_output_filter_policy }}
 
 
 # Configure IPv6 if ip6tables is present.
@@ -138,7 +144,13 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
   ip6tables -A INPUT -m limit --limit 15/minute -j LOG --log-level 7 --log-prefix "Dropped by firewall: "
   {% endif %}
 
-  # Drop all other traffic.
-  ip6tables -A INPUT -j DROP
+  # Configure default behavior for all other incoming traffic.
+  ip6tables -P INPUT {{ firewall_input_filter_policy }}
+
+  # Configure default behavior for all other forwarded traffic.
+  ip6tables -P FORWARD {{ firewall_forward_filter_policy }}
+
+  # Configure default behavior for all other outgoing traffic.
+  ip6tables -P OUTPUT {{ firewall_output_filter_policy }}
 
 fi

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -62,7 +62,9 @@ iptables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
 {% endfor %}
 
 # Accept icmp ping requests.
+{% if firewall_allow_incoming_icmp %}
 iptables -A INPUT -p icmp -j ACCEPT
+{% endif %}
 
 # Allow NTP traffic for time synchronization.
 iptables -A OUTPUT -p udp --dport 123 -j ACCEPT
@@ -108,7 +110,9 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
   {% endfor %}
 
   # Accept icmp ping requests.
-  ip6tables -A INPUT -p icmp -j ACCEPT
+  {% if firewall_allow_incoming_icmp %}
+  ip6tables -A INPUT -p icmpv6 -j ACCEPT
+  {% endif %}
 
   # Allow NTP traffic for time synchronization.
   ip6tables -A OUTPUT -p udp --dport 123 -j ACCEPT

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -67,8 +67,10 @@ iptables -A INPUT -p icmp -j ACCEPT
 {% endif %}
 
 # Allow NTP traffic for time synchronization.
+{% if firewall_allow_ntp %}
 iptables -A OUTPUT -p udp --dport 123 -j ACCEPT
 iptables -A INPUT -p udp --sport 123 -j ACCEPT
+{% endif %}
 
 # Additional custom rules.
 {% for rule in firewall_additional_rules %}
@@ -115,8 +117,10 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
   {% endif %}
 
   # Allow NTP traffic for time synchronization.
+  {% if firewall_allow_ntp %}
   ip6tables -A OUTPUT -p udp --dport 123 -j ACCEPT
   ip6tables -A INPUT -p udp --sport 123 -j ACCEPT
+  {% endif %}
 
   # Additional custom rules.
   {% for rule in firewall_ip6_additional_rules %}


### PR DESCRIPTION
- Fix IPv6 ICMP rule. It's `icmpv6` or `ipv6-icmp` instead of `icmp`.
  See [ip6tables man page](https://linux.die.net/man/8/ip6tables) for further information.
- The users can now decide if they want to use the default ICMP and NTP rules.
- Changed from a rule based DROP of packages to a policy based drop, which behavior is also configurable by the user.