### PR TITLE
Add variable for enabling ipv6/ip6tables configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Whether to log dropped packets to syslog (messages will be prefixed with "Droppe
 
 Set to `true` to disable firewalld (installed by default on RHEL/CentOS) or ufw (installed by default on Ubuntu), respectively.
 
+    firewall_enable_ipv6: false
+
+Set to `false` to disable configuration of ip6tables (for example, if your GRUB_CMDLINE_LINUX contains "ipv6.disable=1").
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ firewall_allowed_udp_ports: []
 firewall_forwarded_tcp_ports: []
 firewall_forwarded_udp_ports: []
 firewall_additional_rules: []
+firewall_enable_ipv6: true
 firewall_ip6_additional_rules: []
 firewall_log_dropped_packets: true
 

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -87,7 +87,7 @@ iptables -A INPUT -m limit --limit 15/minute -j LOG --log-level 7 --log-prefix "
 # Drop all other traffic.
 iptables -A INPUT -j DROP
 
-
+{% if firewall_enable_ipv6 %}
 # Configure IPv6 if ip6tables is present.
 if [ -x "$(which ip6tables 2>/dev/null)" ]; then
 
@@ -134,3 +134,4 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
   ip6tables -A INPUT -j DROP
 
 fi
+{% endif %}


### PR DESCRIPTION
Needed for when IPv6 is disabled on the machine, yet the `ip6tables` binary is installed because `iptables` is installed:

```
[root@localhost ~]# yum provides /sbin/ip6tables
iptables-1.4.21-28.el7.x86_64 : Tools for managing Linux kernel packet filtering capabilities
Repo        : @cr
Matched from:
Filename    : /sbin/ip6tables
```