### PR TITLE
Added conditional ip6tables -F to systemd ExecStop

### DIFF
--- a/templates/firewall.unit.j2
+++ b/templates/firewall.unit.j2
@@ -6,6 +6,9 @@ After=syslog.target network.target
 Type=oneshot
 ExecStart=/etc/firewall.bash
 ExecStop=/sbin/iptables -F
+{% if firewall_enable_ipv6 %}
+ExecStop=/sbin/ip6tables -F
+{% endif %}
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
When using ipv6, the unit service aren't flushing ip6tables. 
Added condition to the unit template with another ExecStop command