### PR TITLE
Actually set INPUT chain policy

### DIFF
--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -85,7 +85,7 @@ iptables -A INPUT -m limit --limit 15/minute -j LOG --log-level 7 --log-prefix "
 {% endif %}
 
 # Drop all other traffic.
-iptables -A INPUT -j DROP
+iptables -P INPUT DROP
 
 {% if firewall_enable_ipv6 %}
 # Configure IPv6 if ip6tables is present.
@@ -131,7 +131,7 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
   {% endif %}
 
   # Drop all other traffic.
-  ip6tables -A INPUT -j DROP
+  ip6tables -P INPUT DROP
 
 fi
 {% endif %}


### PR DESCRIPTION
The iptables syntax for dropping packets by default is wrong and therefore the firewall doesn't actually do anything.