### PR TITLE
Fix systemd unit ordering

### DIFF
--- a/templates/firewall.unit.j2
+++ b/templates/firewall.unit.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=Firewall
-After=syslog.target network.target
+After=syslog.target network-pre.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
According to https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/ firewall services should be ordered after network-pre.target (as opposed to network.target currently in use).