### PR TITLE
Defaults: Use ansible_port if defined instead of 22

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ firewall_enabled_at_boot: true
 firewall_flush_rules_and_chains: true
 
 firewall_allowed_tcp_ports:
-  - "22"
+  - '{% if ansible_port is defined %}{{ ansible_port }}{% else %}22{% endif %}'
   - "25"
   - "80"
   - "443"


### PR DESCRIPTION
Make `firewall_allowed_tcp_ports` more flexible by using `ansible_port` if defined and falling back to `22` if not.

This is a proposal to implement issue #76 which I submitted.

I'm not very familiar with jinja2 templates so there may be a simpler way to implement it instead of the if else...