### PR TITLE
Make flushing on restart truly optional

### DIFF
--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -86,6 +86,8 @@ iptables -A INPUT -m limit --limit 15/minute -j LOG --log-level 7 --log-prefix "
 # Drop all other traffic.
 iptables -A INPUT -j DROP
 
+iptables-save | awk '!visited[$0]++' | iptables-restore
+
 {% if firewall_enable_ipv6 %}
 # Configure IPv6 if ip6tables is present.
 if [ -x "$(which ip6tables 2>/dev/null)" ]; then
@@ -133,6 +135,8 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
 
   # Drop all other traffic.
   ip6tables -A INPUT -j DROP
+
+  ip6tables-save | awk '!visited[$0]++' | ip6tables-restore
 
 fi
 {% endif %}

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -86,7 +86,7 @@ iptables -A INPUT -m limit --limit 15/minute -j LOG --log-level 7 --log-prefix "
 # Drop all other traffic.
 iptables -A INPUT -j DROP
 
-iptables-save | awk '!visited[$0]++' | iptables-restore
+iptables-save | awk '/^COMMIT$/ { delete x; }; !x[$0]++' | uniq | iptables-restore
 
 {% if firewall_enable_ipv6 %}
 # Configure IPv6 if ip6tables is present.
@@ -136,7 +136,7 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
   # Drop all other traffic.
   ip6tables -A INPUT -j DROP
 
-  ip6tables-save | awk '!visited[$0]++' | ip6tables-restore
+  ip6tables-save | awk '/^COMMIT$/ { delete x; }; !x[$0]++' | uniq | ip6tables-restore
 
 fi
 {% endif %}

--- a/templates/firewall.unit.j2
+++ b/templates/firewall.unit.j2
@@ -5,7 +5,9 @@ After=syslog.target network.target
 [Service]
 Type=oneshot
 ExecStart=/etc/firewall.bash
+{% if firewall_flush_rules_and_chains %}
 ExecStop=/sbin/iptables -F
+{% endif %}
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
This update adds the conditional check for `firewall_flush_rules_and_chains` to also not include ExecStop when false.

A side effect of that is that the bash script that triggers on restart will add the same rules to iptables again, duplicating the rules. 

Running `iptables-save | awk '/^COMMIT$/ { delete x; }; !x[$0]++' | uniq | iptables-restore` after all rules have been (re)added will read iptables, remove duplicates and persist the rules.

This operation is probably only needed when we're not flushing on restart but otoh it also doesn't hurt to scrub dupe rules from iptables as a general practice?