### PR TITLE
Ensure apt cache is current

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Ensure apt cache is current.
+  apt:
+    cache_valid_time: 3600
+  when: "ansible_os_family == 'Debian'"
+
 - name: Ensure iptables is present.
   package: name=iptables state=present
 


### PR DESCRIPTION
This PR fixes the issue described in #91 . In summary it adds a task to ensure apt cache is no older than 1hr on Debian based distributions before trying to install it through `package` module.

Fixes: #91 