### PR TITLE
Allow subsequent addition of rules by introducing /etc/firewall.bash.d/

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Whether to flush all rules and chains whenever the firewall is restarted. Set th
       ...
     firewall_allowed_udp_ports: []
 
+In order to open more ports later, you can specify `firewall_group` to create
+new set of rules that will not override the default rules.
+
+    firewall_group: myapp
+    firewall_allowed_tcp_ports:
+      - "1234"
+    firewall_allowed_udp_ports: []
+
 A list of TCP or UDP ports (respectively) to open to incoming traffic.
 
     firewall_forwarded_tcp_ports:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,6 @@ firewall_log_dropped_packets: true
 # Set to true to ensure other firewall management software is disabled.
 firewall_disable_firewalld: false
 firewall_disable_ufw: false
+
+# If you need to remove old GROUP rules, set this true and keep the firewall_group
+firewall_remove: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,6 @@ firewall_disable_ufw: false
 
 # If you need to remove old GROUP rules, set this true and keep the firewall_group
 firewall_remove: false
+
+# handler to reload docker once firewall is flushed
+firewall_reload_docker: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,19 @@ firewall_group: default
 firewall_state: started
 firewall_enabled_at_boot: true
 
+# Legacy option that was controlling flushing all chains. Now we have an option to
+# specify chains explicitely. Thus this variables is used only in the following vars.
 firewall_flush_rules_and_chains: true
+
+# List of chains to flush in each table, empty string means "all", empty list means "none"
+firewall_flush_filter_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
+firewall_flush_nat_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
+firewall_flush_mangle_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
+firewall_ip6_flush_filter_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
+
+# List of chains to delete, empty string means "all", empty list means "none"
+firewall_delete_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
+firewall_ip6_delete_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
 
 firewall_allowed_tcp_ports:
   - "22"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,4 +26,4 @@ firewall_disable_ufw: false
 firewall_remove: false
 
 # handler to reload docker once firewall is flushed
-firewall_reload_docker: false
+firewall_restart_docker: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+firewall_group: default
 firewall_state: started
 firewall_enabled_at_boot: true
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,15 @@
 ---
-- name: restart firewall
+- name: Restart firewall
   service: name=firewall state=restarted
+
+# We need to reload docker so it places all its iptables rules back since the
+# firewall restart blindly flushes all firewall chains (even DOCKER chains)
+# We must have created a dummy shell command because only there notify works
+# Unfortunately ansible does not allow to define the order of handlers from
+# different roles therefore we need to put the docker reload here because
+# the order of handlers is only guaranteed to follow the orfer of how they
+# are defined
+- name: Reload docker
+  service: name=docker state=reloaded
+  ignore_errors: true
+  when: firewall_reload_docker is truthy

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,14 +2,12 @@
 - name: Restart firewall
   service: name=firewall state=restarted
 
-# We need to reload docker so it places all its iptables rules back since the
-# firewall restart blindly flushes all firewall chains (even DOCKER chains)
-# We must have created a dummy shell command because only there notify works
-# Unfortunately ansible does not allow to define the order of handlers from
-# different roles therefore we need to put the docker reload here because
-# the order of handlers is only guaranteed to follow the orfer of how they
-# are defined
-- name: Reload docker
-  service: name=docker state=reloaded
+# Firewall restart blindly flushes all firewall chains (even DOCKER chains).
+# We need to restart docker so it places all its iptables rules back.
+# Unfortunately, Ansible does not allow you to define an order of handlers from
+# different roles. Only order of handlers from one file is guaranteed - it's the 
+# order of their definition.
+- name: Restart docker
+  service: name=docker state=restarted
   ignore_errors: true
-  when: firewall_reload_docker is truthy
+  when: firewall_restart_docker is truthy

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,7 +8,7 @@
     mode: 0744
   notify:
   - Restart firewall
-  - Reload docker
+  - Restart docker
 
 - name: Create firewall IPv6 {{firewall_group}} profile.
   template:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,7 +6,9 @@
     owner: root
     group: root
     mode: 0744
-  notify: restart firewall
+  notify:
+  - Restart firewall
+  - Reload docker
 
 - name: Create firewall IPv6 {{firewall_group}} profile.
   template:
@@ -16,4 +18,3 @@
     group: root
     mode: 0744
   when: firewall_enable_ipv6
-  notify: restart firewall

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,19 @@
+
+- name: Create firewall IPv4 {{firewall_group}} profile.
+  template:
+    src: firewall.group.j2
+    dest: /etc/firewall.bash.d/ipv4.{{firewall_group}}.bash
+    owner: root
+    group: root
+    mode: 0744
+  notify: restart firewall
+
+- name: Create firewall IPv6 {{firewall_group}} profile.
+  template:
+    src: firewall.group.ipv6.j2
+    dest: /etc/firewall.bash.d/ipv6.{{firewall_group}}.bash
+    owner: root
+    group: root
+    mode: 0744
+  when: firewall_enable_ipv6
+  notify: restart firewall

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,6 @@
     owner: root
     group: root
     mode: 0744
-  notify: restart firewall
 
 - name: Create firewall.bash.d/
   file:
@@ -31,6 +30,8 @@
     owner: root
     group: root
     mode: 0744
+  when: firewall_remove is falsy
+  notify: restart firewall
 
 - name: Copy firewall IPv6 GROUP script into place.
   template:
@@ -39,7 +40,22 @@
     owner: root
     group: root
     mode: 0744
-  when: firewall_enable_ipv6
+  when: firewall_remove is falsy and firewall_enable_ipv6
+  notify: restart firewall
+
+- name: Remove IPv4 GROUP script.
+  file:
+    state: absent
+    path: /etc/firewall.bash.d/ipv4.{{firewall_group}}.bash
+  when: firewall_remove
+  notify: restart firewall
+
+- name: Remove IPv6 GROUP script.
+  file:
+    state: absent
+    path: /etc/firewall.bash.d/ipv6.{{firewall_group}}.bash
+  when: firewall_remove
+  notify: restart firewall
 
 - name: Copy firewall init script into place.
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,85 +1,12 @@
 ---
-- name: Ensure iptables is present.
-  package: name=iptables state=present
+- name: Prepare firewall on first run
+  import_tasks: prepare.yml
+  when: firewall_group == "default"
 
-- name: Flush iptables the first time playbook runs.
-  command: >
-    iptables -F
-    creates=/etc/firewall.bash
-
-- name: Copy firewall script into place.
-  template:
-    src: firewall.bash.j2
-    dest: /etc/firewall.bash
-    owner: root
-    group: root
-    mode: 0744
-
-- name: Create firewall.bash.d/
-  file:
-    path: /etc/firewall.bash.d
-    owner: root
-    group: root
-    mode: 0744
-    state: directory
-
-- name: Copy firewall IPv4 GROUP script into place.
-  template:
-    src: firewall.group.j2
-    dest: /etc/firewall.bash.d/ipv4.{{firewall_group}}.bash
-    owner: root
-    group: root
-    mode: 0744
+- name: Install firewall profile {{firewall_group}}
+  import_tasks: install.yml
   when: firewall_remove is falsy
-  notify: restart firewall
 
-- name: Copy firewall IPv6 GROUP script into place.
-  template:
-    src: firewall.group.ipv6.j2
-    dest: /etc/firewall.bash.d/ipv6.{{firewall_group}}.bash
-    owner: root
-    group: root
-    mode: 0744
-  when: firewall_remove is falsy and firewall_enable_ipv6
-  notify: restart firewall
-
-- name: Remove IPv4 GROUP script.
-  file:
-    state: absent
-    path: /etc/firewall.bash.d/ipv4.{{firewall_group}}.bash
-  when: firewall_remove
-  notify: restart firewall
-
-- name: Remove IPv6 GROUP script.
-  file:
-    state: absent
-    path: /etc/firewall.bash.d/ipv6.{{firewall_group}}.bash
-  when: firewall_remove
-  notify: restart firewall
-
-- name: Copy firewall init script into place.
-  template:
-    src: firewall.init.j2
-    dest: /etc/init.d/firewall
-    owner: root
-    group: root
-    mode: 0755
-  when: "ansible_service_mgr != 'systemd'"
-
-- name: Copy firewall systemd unit file into place (for systemd systems).
-  template:
-    src: firewall.unit.j2
-    dest: /etc/systemd/system/firewall.service
-    owner: root
-    group: root
-    mode: 0644
-  when: "ansible_service_mgr == 'systemd'"
-
-- name: Configure the firewall service.
-  service:
-    name: firewall
-    state: "{{ firewall_state }}"
-    enabled: "{{ firewall_enabled_at_boot }}"
-
-- import_tasks: disable-other-firewalls.yml
-  when: firewall_disable_firewalld or firewall_disable_ufw
+- name: Remove firewall profile {{firewall_group}}
+  import_tasks: remove.yml
+  when: firewall_remove is truthy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,15 +16,6 @@
     mode: 0744
   notify: restart firewall
 
-- name: Copy firewall script into place.
-  template:
-    src: firewall.bash.j2
-    dest: /etc/firewall.bash
-    owner: root
-    group: root
-    mode: 0744
-  notify: restart firewall
-
 - name: Create firewall.bash.d/
   file:
     path: /etc/firewall.bash.d

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,21 +25,30 @@
     mode: 0744
   notify: restart firewall
 
-- name: Create firewall.accept.d/
+- name: Create firewall.bash.d/
   file:
-    path: /etc/firewall.accept.d
+    path: /etc/firewall.bash.d
     owner: root
     group: root
     mode: 0744
     state: directory
 
-- name: Copy firewall ACCEPT script into place.
+- name: Copy firewall IPv4 GROUP script into place.
   template:
-    src: firewall.accept.j2
-    dest: /etc/firewall.accept.d/default.bash
+    src: firewall.group.j2
+    dest: /etc/firewall.bash.d/ipv4.{{firewall_group}}.bash
     owner: root
     group: root
     mode: 0744
+
+- name: Copy firewall IPv6 GROUP script into place.
+  template:
+    src: firewall.group.ipv6.j2
+    dest: /etc/firewall.bash.d/ipv6.{{firewall_group}}.bash
+    owner: root
+    group: root
+    mode: 0744
+  when: firewall_enable_ipv6
 
 - name: Copy firewall init script into place.
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,31 @@
     mode: 0744
   notify: restart firewall
 
+- name: Copy firewall script into place.
+  template:
+    src: firewall.bash.j2
+    dest: /etc/firewall.bash
+    owner: root
+    group: root
+    mode: 0744
+  notify: restart firewall
+
+- name: Create firewall.accept.d/
+  file:
+    path: /etc/firewall.accept.d
+    owner: root
+    group: root
+    mode: 0744
+    state: directory
+
+- name: Copy firewall ACCEPT script into place.
+  template:
+    src: firewall.accept.j2
+    dest: /etc/firewall.accept.d/default.bash
+    owner: root
+    group: root
+    mode: 0744
+
 - name: Copy firewall init script into place.
   template:
     src: firewall.init.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Prepare firewall on first run
-  import_tasks: prepare.yml
+  include_tasks: prepare.yml
   when: firewall_group == "default"
 
 - name: Install firewall profile {{firewall_group}}
-  import_tasks: install.yml
+  include_tasks: install.yml
   when: firewall_remove is falsy
 
 - name: Remove firewall profile {{firewall_group}}
-  import_tasks: remove.yml
+  include_tasks: remove.yml
   when: firewall_remove is truthy

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -1,0 +1,51 @@
+---
+- name: Ensure iptables is present.
+  package: name=iptables state=present
+
+- name: Flush iptables the first time playbook runs.
+  command: >
+    iptables -F
+    creates=/etc/firewall.bash
+
+- name: Copy firewall script into place.
+  template:
+    src: firewall.bash.j2
+    dest: /etc/firewall.bash
+    owner: root
+    group: root
+    mode: 0744
+
+- name: Create firewall.bash.d/
+  file:
+    path: /etc/firewall.bash.d
+    owner: root
+    group: root
+    mode: 0744
+    state: directory
+
+- name: Copy firewall init script into place.
+  template:
+    src: firewall.init.j2
+    dest: /etc/init.d/firewall
+    owner: root
+    group: root
+    mode: 0755
+  when: "ansible_service_mgr != 'systemd'"
+
+- name: Copy firewall systemd unit file into place (for systemd systems).
+  template:
+    src: firewall.unit.j2
+    dest: /etc/systemd/system/firewall.service
+    owner: root
+    group: root
+    mode: 0644
+  when: "ansible_service_mgr == 'systemd'"
+
+- name: Configure the firewall service.
+  service:
+    name: firewall
+    state: "{{ firewall_state }}"
+    enabled: "{{ firewall_enabled_at_boot }}"
+
+- import_tasks: disable-other-firewalls.yml
+  when: firewall_disable_firewalld or firewall_disable_ufw

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -3,9 +3,11 @@
   package: name=iptables state=present
 
 - name: Flush iptables the first time playbook runs.
-  command: >
-    iptables -F
-    creates=/etc/firewall.bash
+  ansible.builtin.shell:
+    cmd: iptables -F
+    creates: /etc/firewall.bash
+  become: true
+  when: firewall_flush_rules_and_chains
 
 - name: Copy firewall script into place.
   template:

--- a/tasks/remove.yml
+++ b/tasks/remove.yml
@@ -3,10 +3,14 @@
   file:
     state: absent
     path: /etc/firewall.bash.d/ipv4.{{firewall_group}}.bash
-  notify: restart firewall
+  notify:
+  - Restart firewall
+  - Reload docker
 
 - name: Remove firewall IPv6 {{firewall_group}} profile.
   file:
     state: absent
     path: /etc/firewall.bash.d/ipv6.{{firewall_group}}.bash
-  notify: restart firewall
+  notify:
+  - Restart firewall
+  - Reload docker

--- a/tasks/remove.yml
+++ b/tasks/remove.yml
@@ -1,0 +1,12 @@
+---
+- name: Remove firewall IPv4 {{firewall_group}} profile.
+  file:
+    state: absent
+    path: /etc/firewall.bash.d/ipv4.{{firewall_group}}.bash
+  notify: restart firewall
+
+- name: Remove firewall IPv6 {{firewall_group}} profile.
+  file:
+    state: absent
+    path: /etc/firewall.bash.d/ipv6.{{firewall_group}}.bash
+  notify: restart firewall

--- a/tasks/remove.yml
+++ b/tasks/remove.yml
@@ -5,7 +5,7 @@
     path: /etc/firewall.bash.d/ipv4.{{firewall_group}}.bash
   notify:
   - Restart firewall
-  - Reload docker
+  - Restart docker
 
 - name: Remove firewall IPv6 {{firewall_group}} profile.
   file:
@@ -13,4 +13,4 @@
     path: /etc/firewall.bash.d/ipv6.{{firewall_group}}.bash
   notify:
   - Restart firewall
-  - Reload docker
+  - Restart docker

--- a/templates/firewall.accept.j2
+++ b/templates/firewall.accept.j2
@@ -1,0 +1,7 @@
+{# Add a rule for each open port #}
+{% for port in firewall_allowed_tcp_ports %}
+iptables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
+{% endfor %}
+{% for port in firewall_allowed_udp_ports %}
+iptables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
+{% endfor %}

--- a/templates/firewall.accept.j2
+++ b/templates/firewall.accept.j2
@@ -1,7 +1,0 @@
-{# Add a rule for each open port #}
-{% for port in firewall_allowed_tcp_ports %}
-iptables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
-{% endfor %}
-{% for port in firewall_allowed_udp_ports %}
-iptables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
-{% endfor %}

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -52,13 +52,10 @@ iptables -t nat -I OUTPUT -p udp -o lo --dport {{ forwarded_port.src }} -j REDIR
 {% endfor %}
 
 # Open ports.
-{# Add a rule for each open port #}
-{% for port in firewall_allowed_tcp_ports %}
-iptables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
-{% endfor %}
-{% for port in firewall_allowed_udp_ports %}
-iptables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
-{% endfor %}
+for file in /etc/firewall.accept.d/*;
+do
+  source $file
+done
 
 # Accept icmp ping requests.
 iptables -A INPUT -p icmp -j ACCEPT

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -41,19 +41,9 @@ iptables -X
 iptables -A INPUT -i lo -j ACCEPT
 
 # Forwarded ports.
-{# Add a rule for each forwarded port #}
-{% for forwarded_port in firewall_forwarded_tcp_ports %}
-iptables -t nat -I PREROUTING -p tcp --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
-iptables -t nat -I OUTPUT -p tcp -o lo --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
-{% endfor %}
-{% for forwarded_port in firewall_forwarded_udp_ports %}
-iptables -t nat -I PREROUTING -p udp --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
-iptables -t nat -I OUTPUT -p udp -o lo --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
-{% endfor %}
 
 # Open ports.
-for file in /etc/firewall.accept.d/*;
-do
+for file in /etc/firewall.bash.d/ipv4.*; do
   source $file
 done
 
@@ -65,9 +55,7 @@ iptables -A OUTPUT -p udp --dport 123 -j ACCEPT
 iptables -A INPUT -p udp --sport 123 -j ACCEPT
 
 # Additional custom rules.
-{% for rule in firewall_additional_rules %}
-{{ rule }}
-{% endfor %}
+{# Are now part of firewall.bash.d/ #}
 
 # Allow established connections:
 iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
@@ -97,13 +85,9 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
   ip6tables -A INPUT -i lo -j ACCEPT
 
   # Open ports.
-{# Add a rule for each open port #}
-{% for port in firewall_allowed_tcp_ports %}
-  ip6tables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
-{% endfor %}
-{% for port in firewall_allowed_udp_ports %}
-  ip6tables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
-{% endfor %}
+for file in /etc/firewall.bash.d/ipv6.*; do
+  source $file
+done
 
   # Accept icmp ping requests.
   ip6tables -A INPUT -p icmpv6 -j ACCEPT
@@ -113,9 +97,7 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
   ip6tables -A INPUT -p udp --sport 123 -j ACCEPT
 
   # Additional custom rules.
-{% for rule in firewall_ip6_additional_rules %}
-  {{ rule }}
-{% endfor %}
+  {# Are now part of firewall.bash.d/ #}
 
   # Allow established connections:
   ip6tables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -29,13 +29,21 @@ iptables -P INPUT ACCEPT
 iptables -P FORWARD ACCEPT
 iptables -P OUTPUT ACCEPT
 
-{% if firewall_flush_rules_and_chains %}
-# Remove all rules and chains.
-iptables -t nat -F
-iptables -t mangle -F
-iptables -F
-iptables -X
-{% endif %}
+# Remove rules
+{% for chain in firewall_flush_nat_chains %}
+iptables -t nat -F {{ chain }}
+{% endfor %}
+{% for chain in firewall_flush_mangle_chains %}
+iptables -t mangle -F {{ chain }}
+{% endfor %}
+{% for chain in firewall_flush_filter_chains %}
+iptables -F {{ chain }}
+{% endfor %}
+
+# Remove chains
+{% for chain in firewall_delete_chains %}
+iptables -X {{ chain }}
+{% endfor %}
 
 # Accept traffic from loopback interface (localhost).
 iptables -A INPUT -i lo -j ACCEPT
@@ -75,11 +83,22 @@ iptables -A INPUT -j DROP
 # Configure IPv6 if ip6tables is present.
 if [ -x "$(which ip6tables 2>/dev/null)" ]; then
 
-{% if firewall_flush_rules_and_chains %}
-  # Remove all rules and chains.
-  ip6tables -F
-  ip6tables -X
-{% endif %}
+  # Remove rules
+  {% for chain in firewall_flush_nat_chains %}
+  ip6tables -t nat -F {{ chain }}
+  {% endfor %}
+  {% for chain in firewall_flush_mangle_chains %}
+  ip6tables -t mangle -F {{ chain }}
+  {% endfor %}
+  {% for chain in firewall_flush_filter_chains %}
+  ip6tables -F {{ chain }}
+  {% endfor %}
+
+  # Remove chains
+  {% for chain in firewall_delete_chains %}
+  ip6tables -X {{ chain }}
+  {% endfor %}
+
 
   # Accept traffic from loopback interface (localhost).
   ip6tables -A INPUT -i lo -j ACCEPT

--- a/templates/firewall.group.ipv6.j2
+++ b/templates/firewall.group.ipv6.j2
@@ -1,0 +1,11 @@
+{# Add a rule for each open port #}
+{% for port in firewall_allowed_tcp_ports %}
+  ip6tables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
+{% endfor %}
+{% for port in firewall_allowed_udp_ports %}
+  ip6tables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
+{% endfor %}
+
+{% for rule in firewall_ip6_additional_rules %}
+  {{ rule }}
+{% endfor %}

--- a/templates/firewall.group.ipv6.j2
+++ b/templates/firewall.group.ipv6.j2
@@ -1,9 +1,9 @@
 {# Add a rule for each open port #}
 {% for port in firewall_allowed_tcp_ports %}
-  ip6tables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
+ip6tables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
 {% endfor %}
 {% for port in firewall_allowed_udp_ports %}
-  ip6tables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
+ip6tables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
 {% endfor %}
 
 {% for rule in firewall_ip6_additional_rules %}

--- a/templates/firewall.group.j2
+++ b/templates/firewall.group.j2
@@ -1,0 +1,22 @@
+{# Add a rule for each forwarded port #}
+{% for forwarded_port in firewall_forwarded_tcp_ports %}
+iptables -t nat -I PREROUTING -p tcp --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
+iptables -t nat -I OUTPUT -p tcp -o lo --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
+{% endfor %}
+{% for forwarded_port in firewall_forwarded_udp_ports %}
+iptables -t nat -I PREROUTING -p udp --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
+iptables -t nat -I OUTPUT -p udp -o lo --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
+{% endfor %}
+
+
+{# Add a rule for each open port #}
+{% for port in firewall_allowed_tcp_ports %}
+iptables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
+{% endfor %}
+{% for port in firewall_allowed_udp_ports %}
+iptables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
+{% endfor %}
+
+{% for rule in firewall_additional_rules %}
+{{ rule }}
+{% endfor %}

--- a/templates/firewall.init.j2
+++ b/templates/firewall.init.j2
@@ -23,10 +23,12 @@ case "$1" in
     ;;
   stop)
     echo "Stopping firewall."
+    {% if firewall_flush_rules_and_chains %}
     iptables -F
     if [ -x "$(which ip6tables 2>/dev/null)" ]; then
         ip6tables -F
     fi
+    {% endif %}
     ;;
   restart)
     echo "Restarting firewall."

--- a/templates/firewall.unit.j2
+++ b/templates/firewall.unit.j2
@@ -1,6 +1,7 @@
 [Unit]
 Description=Firewall
 After=syslog.target network.target
+Before=docker.service
 
 [Service]
 Type=oneshot

--- a/templates/firewall.unit.j2
+++ b/templates/firewall.unit.j2
@@ -6,7 +6,9 @@ Before=docker.service
 [Service]
 Type=oneshot
 ExecStart=/etc/firewall.bash
+{% if firewall_flush_rules_and_chains %}
 ExecStop=/sbin/iptables -F
+{% endif %}
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
Currently, there is no way of adding rules once they were defined. This PR adds `/etc/firewall.bash.d/` with user-defined rules. New variable `firewall_group` was introduced to distinguish between different "groups" of rules. The default group is called "default". The code should be still 100% compatible.

Example usage in a random tasks file:
```yaml
- name: Allow firewall ports
  become: true
  vars:
    firewall_group: my app
    firewall_allowed_tcp_ports:
    - 8989
    firewall_allowed_udp_ports:
    - 8990
  ansible.builtin.import_role:
    name: geerlingguy.firewall
```