### PR TITLE
Reject spoofed localhost traffic by default

### DIFF
--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -39,6 +39,7 @@ iptables -X
 
 # Accept traffic from loopback interface (localhost).
 iptables -A INPUT -i lo -j ACCEPT
+iptables -A INPUT '!' -i lo -s 127.0.0.0/8 -j REJECT
 
 # Forwarded ports.
 {# Add a rule for each forwarded port #}

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -99,6 +99,7 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
 
   # Accept traffic from loopback interface (localhost).
   ip6tables -A INPUT -i lo -j ACCEPT
+  ip6tables -A INPUT '!' -i lo -s ::1/128 -j REJECT
 
   # Open ports.
 {# Add a rule for each open port #}


### PR DESCRIPTION
As described here: https://unix.stackexchange.com/questions/395328/iptables-rule-for-loopback this change should reject spoofed localhost packages, not coming from the actual localhost interface.