### PR TITLE
Allow subsequent addition of rules by introducing /etc/firewall.bash.d/

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Whether to flush all rules and chains whenever the firewall is restarted. Set th
       ...
     firewall_allowed_udp_ports: []
 
+In order to open more ports later, you can specify `firewall_group` to create
+new set of rules that will not override the default rules.
+
+    firewall_group: myapp
+    firewall_allowed_tcp_ports:
+      - "1234"
+    firewall_allowed_udp_ports: []
+
 A list of TCP or UDP ports (respectively) to open to incoming traffic.
 
     firewall_forwarded_tcp_ports:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,6 @@ firewall_log_dropped_packets: true
 # Set to true to ensure other firewall management software is disabled.
 firewall_disable_firewalld: false
 firewall_disable_ufw: false
+
+# If you need to remove old GROUP rules, set this true and keep the firewall_group
+firewall_remove: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+firewall_group: default
 firewall_state: started
 firewall_enabled_at_boot: true
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,19 @@
+
+- name: Create firewall IPv4 {{firewall_group}} profile.
+  template:
+    src: firewall.group.j2
+    dest: /etc/firewall.bash.d/ipv4.{{firewall_group}}.bash
+    owner: root
+    group: root
+    mode: 0744
+  notify: restart firewall
+
+- name: Create firewall IPv6 {{firewall_group}} profile.
+  template:
+    src: firewall.group.ipv6.j2
+    dest: /etc/firewall.bash.d/ipv6.{{firewall_group}}.bash
+    owner: root
+    group: root
+    mode: 0744
+  when: firewall_enable_ipv6
+  notify: restart firewall

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,6 @@
     owner: root
     group: root
     mode: 0744
-  notify: restart firewall
 
 - name: Create firewall.bash.d/
   file:
@@ -31,6 +30,8 @@
     owner: root
     group: root
     mode: 0744
+  when: firewall_remove is falsy
+  notify: restart firewall
 
 - name: Copy firewall IPv6 GROUP script into place.
   template:
@@ -39,7 +40,22 @@
     owner: root
     group: root
     mode: 0744
-  when: firewall_enable_ipv6
+  when: firewall_remove is falsy and firewall_enable_ipv6
+  notify: restart firewall
+
+- name: Remove IPv4 GROUP script.
+  file:
+    state: absent
+    path: /etc/firewall.bash.d/ipv4.{{firewall_group}}.bash
+  when: firewall_remove
+  notify: restart firewall
+
+- name: Remove IPv6 GROUP script.
+  file:
+    state: absent
+    path: /etc/firewall.bash.d/ipv6.{{firewall_group}}.bash
+  when: firewall_remove
+  notify: restart firewall
 
 - name: Copy firewall init script into place.
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,85 +1,12 @@
 ---
-- name: Ensure iptables is present.
-  package: name=iptables state=present
+- name: Prepare firewall on first run
+  import_tasks: prepare.yml
+  when: firewall_group == "default"
 
-- name: Flush iptables the first time playbook runs.
-  command: >
-    iptables -F
-    creates=/etc/firewall.bash
-
-- name: Copy firewall script into place.
-  template:
-    src: firewall.bash.j2
-    dest: /etc/firewall.bash
-    owner: root
-    group: root
-    mode: 0744
-
-- name: Create firewall.bash.d/
-  file:
-    path: /etc/firewall.bash.d
-    owner: root
-    group: root
-    mode: 0744
-    state: directory
-
-- name: Copy firewall IPv4 GROUP script into place.
-  template:
-    src: firewall.group.j2
-    dest: /etc/firewall.bash.d/ipv4.{{firewall_group}}.bash
-    owner: root
-    group: root
-    mode: 0744
+- name: Install firewall profile {{firewall_group}}
+  import_tasks: install.yml
   when: firewall_remove is falsy
-  notify: restart firewall
 
-- name: Copy firewall IPv6 GROUP script into place.
-  template:
-    src: firewall.group.ipv6.j2
-    dest: /etc/firewall.bash.d/ipv6.{{firewall_group}}.bash
-    owner: root
-    group: root
-    mode: 0744
-  when: firewall_remove is falsy and firewall_enable_ipv6
-  notify: restart firewall
-
-- name: Remove IPv4 GROUP script.
-  file:
-    state: absent
-    path: /etc/firewall.bash.d/ipv4.{{firewall_group}}.bash
-  when: firewall_remove
-  notify: restart firewall
-
-- name: Remove IPv6 GROUP script.
-  file:
-    state: absent
-    path: /etc/firewall.bash.d/ipv6.{{firewall_group}}.bash
-  when: firewall_remove
-  notify: restart firewall
-
-- name: Copy firewall init script into place.
-  template:
-    src: firewall.init.j2
-    dest: /etc/init.d/firewall
-    owner: root
-    group: root
-    mode: 0755
-  when: "ansible_service_mgr != 'systemd'"
-
-- name: Copy firewall systemd unit file into place (for systemd systems).
-  template:
-    src: firewall.unit.j2
-    dest: /etc/systemd/system/firewall.service
-    owner: root
-    group: root
-    mode: 0644
-  when: "ansible_service_mgr == 'systemd'"
-
-- name: Configure the firewall service.
-  service:
-    name: firewall
-    state: "{{ firewall_state }}"
-    enabled: "{{ firewall_enabled_at_boot }}"
-
-- import_tasks: disable-other-firewalls.yml
-  when: firewall_disable_firewalld or firewall_disable_ufw
+- name: Remove firewall profile {{firewall_group}}
+  import_tasks: remove.yml
+  when: firewall_remove is truthy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,15 +16,6 @@
     mode: 0744
   notify: restart firewall
 
-- name: Copy firewall script into place.
-  template:
-    src: firewall.bash.j2
-    dest: /etc/firewall.bash
-    owner: root
-    group: root
-    mode: 0744
-  notify: restart firewall
-
 - name: Create firewall.bash.d/
   file:
     path: /etc/firewall.bash.d

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,21 +25,30 @@
     mode: 0744
   notify: restart firewall
 
-- name: Create firewall.accept.d/
+- name: Create firewall.bash.d/
   file:
-    path: /etc/firewall.accept.d
+    path: /etc/firewall.bash.d
     owner: root
     group: root
     mode: 0744
     state: directory
 
-- name: Copy firewall ACCEPT script into place.
+- name: Copy firewall IPv4 GROUP script into place.
   template:
-    src: firewall.accept.j2
-    dest: /etc/firewall.accept.d/default.bash
+    src: firewall.group.j2
+    dest: /etc/firewall.bash.d/ipv4.{{firewall_group}}.bash
     owner: root
     group: root
     mode: 0744
+
+- name: Copy firewall IPv6 GROUP script into place.
+  template:
+    src: firewall.group.ipv6.j2
+    dest: /etc/firewall.bash.d/ipv6.{{firewall_group}}.bash
+    owner: root
+    group: root
+    mode: 0744
+  when: firewall_enable_ipv6
 
 - name: Copy firewall init script into place.
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,31 @@
     mode: 0744
   notify: restart firewall
 
+- name: Copy firewall script into place.
+  template:
+    src: firewall.bash.j2
+    dest: /etc/firewall.bash
+    owner: root
+    group: root
+    mode: 0744
+  notify: restart firewall
+
+- name: Create firewall.accept.d/
+  file:
+    path: /etc/firewall.accept.d
+    owner: root
+    group: root
+    mode: 0744
+    state: directory
+
+- name: Copy firewall ACCEPT script into place.
+  template:
+    src: firewall.accept.j2
+    dest: /etc/firewall.accept.d/default.bash
+    owner: root
+    group: root
+    mode: 0744
+
 - name: Copy firewall init script into place.
   template:
     src: firewall.init.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Prepare firewall on first run
-  import_tasks: prepare.yml
+  include_tasks: prepare.yml
   when: firewall_group == "default"
 
 - name: Install firewall profile {{firewall_group}}
-  import_tasks: install.yml
+  include_tasks: install.yml
   when: firewall_remove is falsy
 
 - name: Remove firewall profile {{firewall_group}}
-  import_tasks: remove.yml
+  include_tasks: remove.yml
   when: firewall_remove is truthy

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -1,0 +1,51 @@
+---
+- name: Ensure iptables is present.
+  package: name=iptables state=present
+
+- name: Flush iptables the first time playbook runs.
+  command: >
+    iptables -F
+    creates=/etc/firewall.bash
+
+- name: Copy firewall script into place.
+  template:
+    src: firewall.bash.j2
+    dest: /etc/firewall.bash
+    owner: root
+    group: root
+    mode: 0744
+
+- name: Create firewall.bash.d/
+  file:
+    path: /etc/firewall.bash.d
+    owner: root
+    group: root
+    mode: 0744
+    state: directory
+
+- name: Copy firewall init script into place.
+  template:
+    src: firewall.init.j2
+    dest: /etc/init.d/firewall
+    owner: root
+    group: root
+    mode: 0755
+  when: "ansible_service_mgr != 'systemd'"
+
+- name: Copy firewall systemd unit file into place (for systemd systems).
+  template:
+    src: firewall.unit.j2
+    dest: /etc/systemd/system/firewall.service
+    owner: root
+    group: root
+    mode: 0644
+  when: "ansible_service_mgr == 'systemd'"
+
+- name: Configure the firewall service.
+  service:
+    name: firewall
+    state: "{{ firewall_state }}"
+    enabled: "{{ firewall_enabled_at_boot }}"
+
+- import_tasks: disable-other-firewalls.yml
+  when: firewall_disable_firewalld or firewall_disable_ufw

--- a/tasks/remove.yml
+++ b/tasks/remove.yml
@@ -1,0 +1,12 @@
+---
+- name: Remove firewall IPv4 {{firewall_group}} profile.
+  file:
+    state: absent
+    path: /etc/firewall.bash.d/ipv4.{{firewall_group}}.bash
+  notify: restart firewall
+
+- name: Remove firewall IPv6 {{firewall_group}} profile.
+  file:
+    state: absent
+    path: /etc/firewall.bash.d/ipv6.{{firewall_group}}.bash
+  notify: restart firewall

--- a/templates/firewall.accept.j2
+++ b/templates/firewall.accept.j2
@@ -1,0 +1,7 @@
+{# Add a rule for each open port #}
+{% for port in firewall_allowed_tcp_ports %}
+iptables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
+{% endfor %}
+{% for port in firewall_allowed_udp_ports %}
+iptables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
+{% endfor %}

--- a/templates/firewall.accept.j2
+++ b/templates/firewall.accept.j2
@@ -1,7 +1,0 @@
-{# Add a rule for each open port #}
-{% for port in firewall_allowed_tcp_ports %}
-iptables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
-{% endfor %}
-{% for port in firewall_allowed_udp_ports %}
-iptables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
-{% endfor %}

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -52,13 +52,10 @@ iptables -t nat -I OUTPUT -p udp -o lo --dport {{ forwarded_port.src }} -j REDIR
 {% endfor %}
 
 # Open ports.
-{# Add a rule for each open port #}
-{% for port in firewall_allowed_tcp_ports %}
-iptables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
-{% endfor %}
-{% for port in firewall_allowed_udp_ports %}
-iptables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
-{% endfor %}
+for file in /etc/firewall.accept.d/*;
+do
+  source $file
+done
 
 # Accept icmp ping requests.
 iptables -A INPUT -p icmp -j ACCEPT

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -41,19 +41,9 @@ iptables -X
 iptables -A INPUT -i lo -j ACCEPT
 
 # Forwarded ports.
-{# Add a rule for each forwarded port #}
-{% for forwarded_port in firewall_forwarded_tcp_ports %}
-iptables -t nat -I PREROUTING -p tcp --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
-iptables -t nat -I OUTPUT -p tcp -o lo --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
-{% endfor %}
-{% for forwarded_port in firewall_forwarded_udp_ports %}
-iptables -t nat -I PREROUTING -p udp --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
-iptables -t nat -I OUTPUT -p udp -o lo --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
-{% endfor %}
 
 # Open ports.
-for file in /etc/firewall.accept.d/*;
-do
+for file in /etc/firewall.bash.d/ipv4.*; do
   source $file
 done
 
@@ -65,9 +55,7 @@ iptables -A OUTPUT -p udp --dport 123 -j ACCEPT
 iptables -A INPUT -p udp --sport 123 -j ACCEPT
 
 # Additional custom rules.
-{% for rule in firewall_additional_rules %}
-{{ rule }}
-{% endfor %}
+{# Are now part of firewall.bash.d/ #}
 
 # Allow established connections:
 iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
@@ -97,13 +85,9 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
   ip6tables -A INPUT -i lo -j ACCEPT
 
   # Open ports.
-{# Add a rule for each open port #}
-{% for port in firewall_allowed_tcp_ports %}
-  ip6tables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
-{% endfor %}
-{% for port in firewall_allowed_udp_ports %}
-  ip6tables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
-{% endfor %}
+for file in /etc/firewall.bash.d/ipv6.*; do
+  source $file
+done
 
   # Accept icmp ping requests.
   ip6tables -A INPUT -p icmpv6 -j ACCEPT
@@ -113,9 +97,7 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
   ip6tables -A INPUT -p udp --sport 123 -j ACCEPT
 
   # Additional custom rules.
-{% for rule in firewall_ip6_additional_rules %}
-  {{ rule }}
-{% endfor %}
+  {# Are now part of firewall.bash.d/ #}
 
   # Allow established connections:
   ip6tables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/templates/firewall.group.ipv6.j2
+++ b/templates/firewall.group.ipv6.j2
@@ -1,0 +1,11 @@
+{# Add a rule for each open port #}
+{% for port in firewall_allowed_tcp_ports %}
+  ip6tables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
+{% endfor %}
+{% for port in firewall_allowed_udp_ports %}
+  ip6tables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
+{% endfor %}
+
+{% for rule in firewall_ip6_additional_rules %}
+  {{ rule }}
+{% endfor %}

--- a/templates/firewall.group.ipv6.j2
+++ b/templates/firewall.group.ipv6.j2
@@ -1,9 +1,9 @@
 {# Add a rule for each open port #}
 {% for port in firewall_allowed_tcp_ports %}
-  ip6tables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
+ip6tables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
 {% endfor %}
 {% for port in firewall_allowed_udp_ports %}
-  ip6tables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
+ip6tables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
 {% endfor %}
 
 {% for rule in firewall_ip6_additional_rules %}

--- a/templates/firewall.group.j2
+++ b/templates/firewall.group.j2
@@ -1,0 +1,22 @@
+{# Add a rule for each forwarded port #}
+{% for forwarded_port in firewall_forwarded_tcp_ports %}
+iptables -t nat -I PREROUTING -p tcp --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
+iptables -t nat -I OUTPUT -p tcp -o lo --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
+{% endfor %}
+{% for forwarded_port in firewall_forwarded_udp_ports %}
+iptables -t nat -I PREROUTING -p udp --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
+iptables -t nat -I OUTPUT -p udp -o lo --dport {{ forwarded_port.src }} -j REDIRECT --to-port {{ forwarded_port.dest }}
+{% endfor %}
+
+
+{# Add a rule for each open port #}
+{% for port in firewall_allowed_tcp_ports %}
+iptables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
+{% endfor %}
+{% for port in firewall_allowed_udp_ports %}
+iptables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
+{% endfor %}
+
+{% for rule in firewall_additional_rules %}
+{{ rule }}
+{% endfor %}


### PR DESCRIPTION
Currently, there is no way of adding rules once they were defined. This PR adds `/etc/firewall.bash.d/` with user-defined rules. New variable `firewall_group` was introduced to distinguish between different "groups" of rules. The default group is called "default". The code should be still 100% compatible.

Example usage in a random tasks file:
```yaml
- name: Allow firewall ports
  become: true
  vars:
    firewall_group: my app
    firewall_allowed_tcp_ports:
    - 8989
    firewall_allowed_udp_ports:
    - 8990
  ansible.builtin.import_role:
    name: geerlingguy.firewall
```