### PR TITLE
Made iptables initialization a bit more flexible ... take 2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,19 @@
 firewall_state: started
 firewall_enabled_at_boot: true
 
+# Legacy option that was controlling flushing all chains. Now we have an option to
+# specify chains explicitely. Thus this variables is used only in the following vars.
 firewall_flush_rules_and_chains: true
+
+# List of chains to flush in each table, empty string means "all", empty list means "none"
+firewall_flush_filter_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
+firewall_flush_nat_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
+firewall_flush_mangle_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
+firewall_ip6_flush_filter_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
+
+# List of chains to delete, empty string means "all", empty list means "none"
+firewall_delete_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
+firewall_ip6_delete_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
 
 firewall_allowed_tcp_ports:
   - "22"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,11 +10,9 @@ firewall_flush_rules_and_chains: true
 firewall_flush_filter_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
 firewall_flush_nat_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
 firewall_flush_mangle_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
-firewall_ip6_flush_filter_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
 
 # List of chains to delete, empty string means "all", empty list means "none"
 firewall_delete_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
-firewall_ip6_delete_chains: "{{[] + ([''] if firewall_flush_rules_and_chains else [])}}"
 
 firewall_allowed_tcp_ports:
   - "22"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,9 +3,11 @@
   package: name=iptables state=present
 
 - name: Flush iptables the first time playbook runs.
-  command: >
-    iptables -F
-    creates=/etc/firewall.bash
+  ansible.builtin.shell:
+    cmd: iptables -F
+    creates: /etc/firewall.bash
+  become: true
+  when: firewall_flush_rules_and_chains
 
 - name: Copy firewall script into place.
   template:

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -29,13 +29,21 @@ iptables -P INPUT ACCEPT
 iptables -P FORWARD ACCEPT
 iptables -P OUTPUT ACCEPT
 
-{% if firewall_flush_rules_and_chains %}
-# Remove all rules and chains.
-iptables -t nat -F
-iptables -t mangle -F
-iptables -F
-iptables -X
-{% endif %}
+# Remove rules
+{% for chain in firewall_flush_nat_chains %}
+iptables -t nat -F {{ chain }}
+{% endfor %}
+{% for chain in firewall_flush_mangle_chains %}
+iptables -t mangle -F {{ chain }}
+{% endfor %}
+{% for chain in firewall_flush_filter_chains %}
+iptables -F {{ chain }}
+{% endfor %}
+
+# Remove chains
+{% for chain in firewall_delete_chains %}
+iptables -X {{ chain }}
+{% endfor %}
 
 # Accept traffic from loopback interface (localhost).
 iptables -A INPUT -i lo -j ACCEPT
@@ -90,11 +98,22 @@ iptables -A INPUT -j DROP
 # Configure IPv6 if ip6tables is present.
 if [ -x "$(which ip6tables 2>/dev/null)" ]; then
 
-{% if firewall_flush_rules_and_chains %}
-  # Remove all rules and chains.
-  ip6tables -F
-  ip6tables -X
-{% endif %}
+  # Remove rules
+  {% for chain in firewall_flush_nat_chains %}
+  ip6tables -t nat -F {{ chain }}
+  {% endfor %}
+  {% for chain in firewall_flush_mangle_chains %}
+  ip6tables -t mangle -F {{ chain }}
+  {% endfor %}
+  {% for chain in firewall_flush_filter_chains %}
+  ip6tables -F {{ chain }}
+  {% endfor %}
+
+  # Remove chains
+  {% for chain in firewall_delete_chains %}
+  ip6tables -X {{ chain }}
+  {% endfor %}
+
 
   # Accept traffic from loopback interface (localhost).
   ip6tables -A INPUT -i lo -j ACCEPT

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -99,12 +99,6 @@ iptables -A INPUT -j DROP
 if [ -x "$(which ip6tables 2>/dev/null)" ]; then
 
   # Remove rules
-  {% for chain in firewall_flush_nat_chains %}
-  ip6tables -t nat -F {{ chain }}
-  {% endfor %}
-  {% for chain in firewall_flush_mangle_chains %}
-  ip6tables -t mangle -F {{ chain }}
-  {% endfor %}
   {% for chain in firewall_flush_filter_chains %}
   ip6tables -F {{ chain }}
   {% endfor %}

--- a/templates/firewall.init.j2
+++ b/templates/firewall.init.j2
@@ -23,10 +23,12 @@ case "$1" in
     ;;
   stop)
     echo "Stopping firewall."
+    {% if firewall_flush_rules_and_chains %}
     iptables -F
     if [ -x "$(which ip6tables 2>/dev/null)" ]; then
         ip6tables -F
     fi
+    {% endif %}
     ;;
   restart)
     echo "Restarting firewall."

--- a/templates/firewall.unit.j2
+++ b/templates/firewall.unit.j2
@@ -5,7 +5,9 @@ After=syslog.target network.target
 [Service]
 Type=oneshot
 ExecStart=/etc/firewall.bash
+{% if firewall_flush_rules_and_chains %}
 ExecStop=/sbin/iptables -F
+{% endif %}
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
This is another take of #37 that adds a bit of more backward compatibility
concerning legacy variable `firewall_flush_rules_and_chains`

This enables configuration of which (if any) rules and chains should
be removed. Enables usage alongside other tools that (dynamically)
insert their rules like fail2ban or docker. The default behavior is
following the previous functionality - removing all rules and
non-default chains.

With proper configuration, this should solve issues in https://github.com/geerlingguy/ansible-role-firewall/issues/31