### PR TITLE
Changed: distinguish allowed as incoming allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Controls the state of the firewall service; whether it should be running (`firew
 
 Whether to flush all rules and chains whenever the firewall is restarted. Set this to `false` if there are other processes managing iptables (e.g. Docker).
 
-    firewall_allowed_tcp_ports:
+    firewall_allowed_incoming_tcp_ports:
       - "22"
       - "80"
       ...
-    firewall_allowed_udp_ports: []
+    firewall_allowed_incoming_udp_ports: []
 
 A list of TCP or UDP ports (respectively) to open to incoming traffic.
 
@@ -82,7 +82,7 @@ None.
 
 *Inside `vars/main.yml`*:
 
-    firewall_allowed_tcp_ports:
+    firewall_allowed_incoming_tcp_ports:
       - "22"
       - "25"
       - "80"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,12 +4,12 @@ firewall_enabled_at_boot: true
 
 firewall_flush_rules_and_chains: true
 
-firewall_allowed_tcp_ports:
+firewall_allowed_incoming_tcp_ports:
   - "22"
   - "25"
   - "80"
   - "443"
-firewall_allowed_udp_ports: []
+firewall_allowed_incoming_udp_ports: []
 firewall_forwarded_tcp_ports: []
 firewall_forwarded_udp_ports: []
 firewall_additional_rules: []

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,7 +8,7 @@
     firewall_enable_ipv6: false
 
     # Added for a test.
-    firewall_allowed_tcp_ports:
+    firewall_allowed_incoming_tcp_ports:
       - "9123"
 
   pre_tasks:

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -53,10 +53,10 @@ iptables -t nat -I OUTPUT -p udp -o lo --dport {{ forwarded_port.src }} -j REDIR
 
 # Open ports.
 {# Add a rule for each open port #}
-{% for port in firewall_allowed_tcp_ports %}
+{% for port in firewall_allowed_incoming_tcp_ports %}
 iptables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
 {% endfor %}
-{% for port in firewall_allowed_udp_ports %}
+{% for port in firewall_allowed_incoming_udp_ports %}
 iptables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
 {% endfor %}
 
@@ -101,10 +101,10 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
 
   # Open ports.
 {# Add a rule for each open port #}
-{% for port in firewall_allowed_tcp_ports %}
+{% for port in firewall_allowed_incoming_tcp_ports %}
   ip6tables -A INPUT -p tcp -m tcp --dport {{ port }} -j ACCEPT
 {% endfor %}
-{% for port in firewall_allowed_udp_ports %}
+{% for port in firewall_allowed_incoming_udp_ports %}
   ip6tables -A INPUT -p udp -m udp --dport {{ port }} -j ACCEPT
 {% endfor %}
 


### PR DESCRIPTION
***What does this change do?***

- Distinguish allowed traffic as incoming allowed. It is possible that later outgoing will have separated rules but it appears this is as of yet unimplemented.

***Why is this change needed?***

- To make it clearer to newcomers that incoming traffic is beinf firewalled on said ports