### PR TITLE
Flush rules for INPUT chain only (for compatibility with docker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Controls the state of the firewall service; whether it should be running (`firew
 
 Whether to flush all rules and chains whenever the firewall is restarted. Set this to `false` if there are other processes managing iptables (e.g. Docker).
 
+    firewall_flush_rules_input_nat: false
+    firewall_flush_rules_input_mangle: false
+    firewall_flush_rules_input_filter: false
+
+Whether to flush the INPUT chains in the `nat`, `mangle`, and `filter` tables, respectively, without clearing other chains. These options are only effective when `firewall_flush_rules_and_chains` is set to `false`.
+
     firewall_allowed_tcp_ports:
       - "22"
       - "80"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,12 @@ firewall_enabled_at_boot: true
 
 firewall_flush_rules_and_chains: true
 
+# Flush rules for INPUT chain only
+# (if 'firewall_flush_rules_and_chains' is 'false')
+firewall_flush_rules_input_nat: false
+firewall_flush_rules_input_mangle: false
+firewall_flush_rules_input_filter: false
+
 firewall_allowed_tcp_ports:
   - "22"
   - "25"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,12 +8,6 @@
     creates=/etc/firewall.bash
   when: firewall_flush_rules_and_chains
 
-- name: Flush iptables INPUT filter the first time playbook runs.
-  command: >
-    iptables -F INPUT
-    creates=/etc/firewall.bash
-  when: not firewall_flush_rules_and_chains and firewall_flush_rules_input_filter
-
 - name: Copy firewall script into place.
   template:
     src: firewall.bash.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,13 @@
   command: >
     iptables -F
     creates=/etc/firewall.bash
+  when: firewall_flush_rules_and_chains
+
+- name: Flush iptables INPUT filter the first time playbook runs.
+  command: >
+    iptables -F INPUT
+    creates=/etc/firewall.bash
+  when: not firewall_flush_rules_and_chains and firewall_flush_rules_input_filter
 
 - name: Copy firewall script into place.
   template:

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -39,9 +39,15 @@ iptables -X
 
 {% if not firewall_flush_rules_and_chains %}
 # Remove rules in the INPUT chain
-{% if firewall_flush_rules_input_nat %}iptables -t nat -F INPUT{% endif %}
-{% if firewall_flush_rules_input_mangle %}iptables -t mangle -F INPUT{% endif %}
-{% if firewall_flush_rules_input_filter %}iptables -t filter -F INPUT{% endif %}
+{% if firewall_flush_rules_input_nat %}
+iptables -t nat -F INPUT
+{% endif %}
+{% if firewall_flush_rules_input_mangle -%}
+iptables -t mangle -F INPUT
+{% endif %}
+{% if firewall_flush_rules_input_filter -%}
+iptables -t filter -F INPUT
+{% endif %}
 {% endif %}
 
 # Accept traffic from loopback interface (localhost).

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -37,6 +37,19 @@ iptables -F
 iptables -X
 {% endif %}
 
+{% if not firewall_flush_rules_and_chains %}
+# Remove rules in the INPUT chain
+  {% if firewall_flush_rules_input_nat %}
+iptables -t nat -F INPUT
+  {% endif %}
+  {% if firewall_flush_rules_input_mangle %}
+iptables -t mangle -F INPUT
+  {% endif %}
+  {% if firewall_flush_rules_input_filter %}
+iptables -t filter -F INPUT
+  {% endif %}
+{% endif %}
+
 # Accept traffic from loopback interface (localhost).
 iptables -A INPUT -i lo -j ACCEPT
 

--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -39,15 +39,9 @@ iptables -X
 
 {% if not firewall_flush_rules_and_chains %}
 # Remove rules in the INPUT chain
-  {% if firewall_flush_rules_input_nat %}
-iptables -t nat -F INPUT
-  {% endif %}
-  {% if firewall_flush_rules_input_mangle %}
-iptables -t mangle -F INPUT
-  {% endif %}
-  {% if firewall_flush_rules_input_filter %}
-iptables -t filter -F INPUT
-  {% endif %}
+{% if firewall_flush_rules_input_nat %}iptables -t nat -F INPUT{% endif %}
+{% if firewall_flush_rules_input_mangle %}iptables -t mangle -F INPUT{% endif %}
+{% if firewall_flush_rules_input_filter %}iptables -t filter -F INPUT{% endif %}
 {% endif %}
 
 # Accept traffic from loopback interface (localhost).

--- a/templates/firewall.init.j2
+++ b/templates/firewall.init.j2
@@ -23,9 +23,19 @@ case "$1" in
     ;;
   stop)
     echo "Stopping firewall."
+    {% if firewall_flush_rules_and_chains %}
     iptables -F
+    {% endif %}
+    {% if not firewall_flush_rules_and_chains and firewall_flush_rules_input_filter %}
+    iptables -F INPUT
+    {% endif %}
     if [ -x "$(which ip6tables 2>/dev/null)" ]; then
+        {% if firewall_flush_rules_and_chains %}
         ip6tables -F
+        {% endif %}
+        {% if not firewall_flush_rules_and_chains and firewall_flush_rules_input_filter %}
+        ip6tables -F INPUT
+        {% endif %}
     fi
     ;;
   restart)

--- a/templates/firewall.unit.j2
+++ b/templates/firewall.unit.j2
@@ -5,7 +5,12 @@ After=syslog.target network.target
 [Service]
 Type=oneshot
 ExecStart=/etc/firewall.bash
+{% if firewall_flush_rules_and_chains %}
 ExecStop=/sbin/iptables -F
+{% endif %}
+{% if not firewall_flush_rules_and_chains and firewall_flush_rules_input_filter %}
+ExecStop=/sbin/iptables -F INPUT
+{% endif %}
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
This pull request refactors the firewall playbook to introduce the ability to flush only the INPUT chains, while leaving other chains (such as DOCKER chains) untouched. This change is made to ensure compatibility with Docker configurations.

The following changes have been made:

1. Added new variables:
- `firewall_flush_rules_input_nat`: Indicates whether to flush the INPUT chain in the 'nat' table.
- `firewall_flush_rules_input_mangle`: Indicates whether to flush the INPUT chain in the 'mangle' table.
- `firewall_flush_rules_input_filter`: Indicates whether to flush the INPUT chain in the 'filter' table.

2. Updated the playbook logic:
- The flush rules for the INPUT chain are now conditioned based on the new variables mentioned above.
- This change allows selective flushing of the INPUT chains, leaving other chains untouched.

These changes ensure compatibility with Docker configurations and provide more flexibility in managing firewall rules.
